### PR TITLE
fix: properly handle single character strings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export function jaroWinkler(stringCompare: CharArrayResolvable, stringCompareWit
 }
 
 function getMatching(a1: CharArray, a2: CharArray, matches1: Uint8Array, matches2: Uint8Array) {
-	const matchWindow = Math.floor(Math.max(a1.length, a2.length) / 2) - 1;
+	const matchWindow = Math.floor(Math.max(a1.length, a2.length) / 2);
 
 	let matches = 0;
 	let index1 = 0;

--- a/tests/jaroWinkler.test.ts
+++ b/tests/jaroWinkler.test.ts
@@ -30,4 +30,16 @@ describe('jaro-winkler', () => {
 		expect(approxEql(jaroWinkler('class', 'clams'), 0.90666)).toBe(true);
 		expect(approxEql(jaroWinkler('clams', 'class'), 0.90666)).toBe(true);
 	});
+
+	test('should handle one character strings', () => {
+		expect(approxEql(jaroWinkler('O', 'O'), 1)).toBe(true);
+		expect(approxEql(jaroWinkler('I', 'O'), 0)).toBe(true);
+		expect(approxEql(jaroWinkler('O', 'OA'), 0.85)).toBe(true);
+		expect(approxEql(jaroWinkler('AO', 'A'), 0.85)).toBe(true);
+	});
+
+	test('should handle two character strings', () => {
+		expect(approxEql(jaroWinkler('OA', 'OA'), 1)).toBe(true);
+		expect(approxEql(jaroWinkler('IA', 'OA'), 0.66666)).toBe(true);
+	});
 });


### PR DESCRIPTION
The `matchWindow` was off by one for single character strings. 
This would result in no matches being found even if there were some.